### PR TITLE
Fix IAuthManager.h to avoid linker errors

### DIFF
--- a/src/include/IAuthManager.h
+++ b/src/include/IAuthManager.h
@@ -55,7 +55,7 @@ public:
     virtual int Close() = 0;
     virtual int AuthRequest(const Auth_Request *request) = 0;
 
-    virtual std::string AllocIp();
+    virtual std::string AllocIp() = 0;
     
 };
 


### PR DESCRIPTION
linker generated the following errors:
/root/openbras/libs/libAuthMgr.so: undefined reference to `typeinfo for IAuthManager`
/root/openbras/libs/libAuthMgr.so: undefined reference to `vtable for IAuthManager`